### PR TITLE
Fix syntax error in page.swig

### DIFF
--- a/layout/page.swig
+++ b/layout/page.swig
@@ -3,7 +3,7 @@
 {% block primary %}
 
 {% set pipe = {item: page, index: false} %}
-{% include '_partial/article.swig' with pipe %>
+{% include '_partial/article.swig' with pipe %}
 
 {% include '_partial/disqus_count.swig' %}
 


### PR DESCRIPTION
Fix error to make things work.

`hexo generate` failed because of syntax error.

```
Unhandled rejection Error: SyntaxError: Unexpected token > in file … /page.swig.
```
