### PR TITLE
update pipe value -> index: true

### DIFF
--- a/layout/index.swig
+++ b/layout/index.swig
@@ -5,7 +5,7 @@
 {% block primary %}
 
 	{% for post in page.posts %}
-		{% set pipe = {item: post} %}
+		{% set pipe = {index:true, item: post} %}
 		{% include '_partial/article.swig' with pipe %}
 	{% endfor %}
 


### PR DESCRIPTION
for page Index, if there is no config date for `index`, homepage will always render the whole post, instead of the excerpt. By the way, nice theme, thank you :)